### PR TITLE
Specified sentry's version to 1.10

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,6 @@
 
   "require": {
     "php": "^7.0",
-    "sentry/sentry": "*"
+    "sentry/sentry": "1.10"
   }
 }


### PR DESCRIPTION
Compatibility problems about new version update.
More in: https://github.com/getsentry/sentry-php/blob/ca2ebc096b4839417c0b17d629be4c7ab784cbcd/UPGRADE-2.0.md